### PR TITLE
Rewrite flake (fix overlay)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,35 +22,43 @@
     flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
+        inherit (pkgs) lib;
 
         extensions = self.overlays.default null system;
 
-        vscodiumWithExtensions = let
-          inherit (pkgs) vscode-with-extensions vscodium;
-          vscodium' = vscode-with-extensions.override {
-            vscode = vscodium;
-            vscodeExtensions = builtins.attrValues {
-              inherit (extensions.vscode-marketplace.golang) go;
-              inherit (extensions.vscode-marketplace.vlanguage) vscode-vlang;
-            };
+        vscodium-with-extensions = let
+          package = pkgs.vscode-with-extensions.override {
+            vscode = pkgs.vscodium;
+            vscodeExtensions = with self.extensions.vscode-marketplace; [
+              golang.go
+              vlanguage.vscode-vlang
+            ];
           };
-        in
-          vscodium'
-          // {
-            meta =
-              (builtins.removeAttrs vscodium'.meta ["description"])
-              // {
-                longDescription = ''
-                  This is a sample `VSCodium` (= `VS Code` without proprietary stuff) with a couple of extensions.
+          package' =
+            package
+            // {
+              meta =
+                (removeAttrs package.meta ["description"])
+                // {
+                  longDescription = lib.mdDoc ''
+                    This is a sample overridden VSCodium (FOSS fork of VS Code) with a couple extensions.
+                    You can override this package and set `vscodeExtensions` to a list of extension
+                    derivations, namely those provided by this flake.
 
-                  The [repo](https://github.com/nix-community/nix-vscode-extensions) provides
-                  `VS Code Marketplace` (~40K) and `Open VSX` (~3K) extensions as `Nix` expressions.
-                '';
-              };
-          };
+                    The [repository] provides about 40K extensions from [Visual Studio Marketplace]
+                    and another ~3K from [Open VSX Registry].
+
+                    [repository]: https://github.com/nix-community/nix-vscode-extensions
+                    [Visual Studio Marketplace]: https://marketplace.visualstudio.com/vscode
+                    [Open VSX Registry]: https://open-vsx.org/
+                  '';
+                };
+            };
+        in
+          package';
       in {
         packages = {
-          inherit vscodiumWithExtensions;
+          inherit vscodium-with-extensions;
         };
         inherit extensions;
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/dbc68fa4bb132d990945d39801b0d7f2ba15b08f";
-    flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -16,88 +15,89 @@
   outputs = {
     self,
     nixpkgs,
-    flake-utils,
-    flake-compat,
-  }:
-    flake-utils.lib.eachDefaultSystem (
-      system: let
-        pkgs = nixpkgs.legacyPackages.${system};
-        inherit (pkgs) lib;
-
-        extensions = self.overlays.default null system;
-
-        vscodium-with-extensions = let
-          package = pkgs.vscode-with-extensions.override {
-            vscode = pkgs.vscodium;
-            vscodeExtensions = with self.extensions.vscode-marketplace; [
-              golang.go
-              vlanguage.vscode-vlang
-            ];
-          };
-          package' =
-            package
-            // {
-              meta =
-                (removeAttrs package.meta ["description"])
-                // {
-                  longDescription = lib.mdDoc ''
-                    This is a sample overridden VSCodium (FOSS fork of VS Code) with a couple extensions.
-                    You can override this package and set `vscodeExtensions` to a list of extension
-                    derivations, namely those provided by this flake.
-
-                    The [repository] provides about 40K extensions from [Visual Studio Marketplace]
-                    and another ~3K from [Open VSX Registry].
-
-                    [repository]: https://github.com/nix-community/nix-vscode-extensions
-                    [Visual Studio Marketplace]: https://marketplace.visualstudio.com/vscode
-                    [Open VSX Registry]: https://open-vsx.org/
-                  '';
-                };
-            };
-        in
-          package';
-      in {
-        packages = {
-          inherit vscodium-with-extensions;
-        };
-        inherit extensions;
-      }
-    )
-    // {
-      overlays = {
-        default = _: prev: let
-          inherit (prev) lib;
-          utils = prev.vscode-utils;
-          loadGenerated = path:
-            lib.pipe path [
-              (path:
-                import path {
-                  inherit (prev) fetchgit fetchurl fetchFromGitHub;
-                })
-              (lib.mapAttrsToList (_: extension: {
-                inherit (extension) name;
-                value = utils.buildVscodeMarketplaceExtension {
-                  vsix = extension.src;
-                  mktplcRef = {
-                    inherit (extension) name publisher version;
-                  };
-                };
-              }))
-              (builtins.groupBy ({value, ...}: value.vscodeExtPublisher))
-              (builtins.mapAttrs (_: lib.listToAttrs))
-            ];
-        in {
-          vscode-marketplace = loadGenerated ./data/generated/vscode-marketplace.nix;
-          open-vsx = loadGenerated ./data/generated/open-vsx.nix;
-        };
-      };
-    }
-    // {
-      templates = {
-        default = {
-          path = ./template;
-          description = "VSCodium with extensions";
-        };
+    ...
+  }: let
+    inherit (nixpkgs) lib;
+    defaultSystems = [
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    genSystems = lib.genAttrs defaultSystems;
+  in {
+    templates = {
+      vscodium-with-extensions = {
+        path = ./template;
+        description = "VSCodium with extensions";
       };
     };
+
+    extensions =
+      genSystems (system:
+        self.overlays.default null nixpkgs.legacyPackages.${system});
+
+    overlays = {
+      default = _: prev: let
+        utils = prev.vscode-utils;
+        loadGenerated = path:
+          lib.pipe path [
+            (path:
+              import path {
+                inherit (prev) fetchurl fetchFromGitHub;
+                fetchgit = prev.fetchGit;
+              })
+            (lib.mapAttrsToList (_: extension: {
+              inherit (extension) name;
+              value = utils.buildVscodeMarketplaceExtension {
+                vsix = extension.src;
+                mktplcRef = {
+                  inherit (extension) name publisher version;
+                };
+              };
+            }))
+            (builtins.groupBy ({value, ...}: value.vscodeExtPublisher))
+            (builtins.mapAttrs (_: lib.listToAttrs))
+          ];
+      in {
+        vscode-marketplace = loadGenerated ./data/generated/vscode-marketplace.nix;
+        open-vsx = loadGenerated ./data/generated/open-vsx.nix;
+      };
+    };
+
+    packages = genSystems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      # overrideAttrs is avoided so that Nix can still hit binary cache
+      examplePackage = pkgs.vscode-with-extensions.override {
+        vscode = pkgs.vscodium;
+        vscodeExtensions = with self.extensions.${system}.vscode-marketplace; [
+          golang.go
+          vlanguage.vscode-vlang
+        ];
+      };
+      examplePackage' =
+        examplePackage
+        // {
+          meta =
+            (removeAttrs examplePackage.meta ["description"])
+            // {
+              longDescription = lib.mdDoc ''
+                This is a sample overridden VSCodium (FOSS fork of VS Code) with a couple extensions.
+                You can override this package and set `vscodeExtensions` to a list of extension
+                derivations, namely those provided by this flake.
+
+                The [repository] provides about 40K extensions from [Visual Studio Marketplace]
+                and another ~3K from [Open VSX Registry].
+
+                [repository]: https://github.com/nix-community/nix-vscode-extensions
+                [Visual Studio Marketplace]: https://marketplace.visualstudio.com/vscode
+                [Open VSX Registry]: https://open-vsx.org/
+              '';
+            };
+        };
+    in {
+      vscodium-with-extensions = examplePackage';
+    });
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -13,95 +13,107 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, flake-compat }: flake-utils.lib.eachDefaultSystem
-    (system:
-      let
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    flake-compat,
+  }:
+    flake-utils.lib.eachDefaultSystem
+    (
+      system: let
         pkgs = nixpkgs.legacyPackages.${system};
 
         loadGenerated = set:
-          with builtins; with pkgs; let
+          with builtins;
+          with pkgs; let
             generated = import ./data/generated/${set}.nix {
               inherit fetchurl fetchFromGitHub;
               fetchgit = fetchGit;
             };
 
-            groupedByPublisher = (groupBy (e: e.publisher) (attrValues generated));
+            groupedByPublisher = groupBy (e: e.publisher) (attrValues generated);
             pkgDefinition = {
-              open-vsx = e: with e; with vscode-utils; {
-                inherit name;
-                value = buildVscodeMarketplaceExtension {
-                  vsix = src;
-                  mktplcRef = {
-                    inherit version;
-                    publisher = publisher;
-                    name = name;
-                  };
-                  meta = with lib; {
-                    inherit changelog downloadPage homepage;
-                    license = licenses.${license};
-                  };
-                };
-              };
-              vscode-marketplace = e: with e; with vscode-utils; {
-                inherit name;
-                value = buildVscodeMarketplaceExtension {
-                  vsix = src;
-                  mktplcRef = {
-                    inherit version;
-                    publisher = publisher;
-                    name = name;
+              open-vsx = e:
+                with e;
+                with vscode-utils; {
+                  inherit name;
+                  value = buildVscodeMarketplaceExtension {
+                    vsix = src;
+                    mktplcRef = {
+                      inherit version;
+                      publisher = publisher;
+                      name = name;
+                    };
+                    meta = with lib; {
+                      inherit changelog downloadPage homepage;
+                      license = licenses.${license};
+                    };
                   };
                 };
-              };
+              vscode-marketplace = e:
+                with e;
+                with vscode-utils; {
+                  inherit name;
+                  value = buildVscodeMarketplaceExtension {
+                    vsix = src;
+                    mktplcRef = {
+                      inherit version;
+                      publisher = publisher;
+                      name = name;
+                    };
+                  };
+                };
             };
           in
-          mapAttrs (_: val: listToAttrs (map pkgDefinition.${set} val)) groupedByPublisher;
+            mapAttrs (_: val: listToAttrs (map pkgDefinition.${set} val)) groupedByPublisher;
 
         extensions = {
           vscode-marketplace = loadGenerated "vscode-marketplace";
           open-vsx = loadGenerated "open-vsx";
         };
 
-        vscodiumWithExtensions =
-          let
-            inherit (pkgs) vscode-with-extensions vscodium;
-            vscodium_ =
-              (vscode-with-extensions.override {
-                vscode = vscodium;
-                vscodeExtensions = builtins.attrValues {
-                  inherit (extensions.vscode-marketplace.golang) go;
-                  inherit (extensions.vscode-marketplace.vlanguage) vscode-vlang;
-                };
-              });
-          in
-          vscodium_ // {
-            meta = (builtins.removeAttrs vscodium_.meta [ "description" ]) // {
-              longDescription = ''
-                This is a sample `VSCodium` (= `VS Code` without proprietary stuff) with a couple of extensions.
-              
-                The [repo](https://github.com/nix-community/nix-vscode-extensions) provides
-                `VS Code Marketplace` (~40K) and `Open VSX` (~3K) extensions as `Nix` expressions.
-              '';
+        vscodiumWithExtensions = let
+          inherit (pkgs) vscode-with-extensions vscodium;
+          vscodium_ = vscode-with-extensions.override {
+            vscode = vscodium;
+            vscodeExtensions = builtins.attrValues {
+              inherit (extensions.vscode-marketplace.golang) go;
+              inherit (extensions.vscode-marketplace.vlanguage) vscode-vlang;
             };
           };
-      in
-      {
+        in
+          vscodium_
+          // {
+            meta =
+              (builtins.removeAttrs vscodium_.meta ["description"])
+              // {
+                longDescription = ''
+                  This is a sample `VSCodium` (= `VS Code` without proprietary stuff) with a couple of extensions.
+
+                  The [repo](https://github.com/nix-community/nix-vscode-extensions) provides
+                  `VS Code Marketplace` (~40K) and `Open VSX` (~3K) extensions as `Nix` expressions.
+                '';
+              };
+          };
+      in {
         packages = {
           inherit vscodiumWithExtensions;
         };
         inherit extensions;
       }
-    ) // {
-    overlays.default = final: prev: {
-      vscode-extensions = self.extensions.${prev.system};
-    };
-  }
-  // {
-    templates = {
-      default = {
-        path = ./template;
-        description = "VSCodium with extensions";
+    )
+    // {
+      overlays.default = final: prev: {
+        vscode-extensions = self.extensions.${prev.system};
+      };
+    }
+    // {
+      templates = {
+        default = {
+          path = ./template;
+          description = "VSCodium with extensions";
+        };
       };
     };
-  };
 }


### PR DESCRIPTION
The way that the overlay was set up was fundamentally flawed. When discussing issues I was having on the unofficial Discord server, I learned how overlays are supposed to work, and have now fixed the default overlay for this flake.

I have also taken the liberty of re-writing the entire thing. In order to make the entire process of turning the generated fetcher expressions into derivations simpler, I have removed some metadata from the packages generated from Open VSX Registry.

If you are okay with the invasive nature of the changes I've made, I'd like to keep going and replace more of the code here.