### PR TITLE
Update README & specify default template

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ That said, you can now use a different set of extensions for `VS Code`/`VSCodium
 
 ## Template
 
-This repository provides a [template](templates/flake.nix).
+This repository provides a [template](template/flake.nix).
 This template provides a [VSCodium](https://github.com/VSCodium/vscodium) with a couple of extensions.
 Try it:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nix expressions for VS Code Extensions
 
-At the time of writing this, searching `nixpkgs` yields around **200** `VS Code` extensions. However, the `VS Code Marketplace` contains more than **40,000** extensions!
+At the time of writing this, `nixpkgs` contains **271** `VS Code` extensions. This is a small fraction of the more than **40,000** extensions in the `VS Code Marketplace`! In addition, many of the extensions in `nixpkgs` are significantly out-of-date.
 
 This flake provides Nix expressions for the majority of available extensions from [Open VSX](https://open-vsx.org/) and [VS Code Marketplace](https://marketplace.visualstudio.com/vscode). A `GitHub Action` updates the extensions daily.
 

--- a/flake.nix
+++ b/flake.nix
@@ -113,6 +113,7 @@
           path = ./template;
           description = "VSCodium with extensions";
         };
+        default = self.templates.vscodium-with-extensions;
       };
     }
     // (eachDefaultSystem (system:


### PR DESCRIPTION
The changes are as described on the tin. 

I found that since `flake.nix` did not specify a default template, so my attempts at just running the provided `nix flake new ...` command in the README no longer worked. So, instead of changing the README to specify the particular template, I specified that the `vscodium-with-extensions` template should be the default one.

Other than that, I fixed a broken link and changed some wording of the first paragraph.

I hope the changes are appreciated!