### PR TITLE
Add release version of ms-vscode-remote.remote-ssh

### DIFF
--- a/.github/config.yaml
+++ b/.github/config.yaml
@@ -12,6 +12,8 @@ vscodeMarketplace:
   release:
     eamodio:
     - gitlens
+    ms-vscode-remote:
+    - remote-ssh
     rust-lang:
     - rust-analyzer
     stkb:


### PR DESCRIPTION
The current pre-release Version of `ms-vscode-remote.remote-ssh` requires the `1.82-insider` build of vscode, but the latest packaged stable vscode build is `1.81.1`.