### PR TITLE
feat(config.yaml): add github.copilot-chat

### DIFF
--- a/.github/config.yaml
+++ b/.github/config.yaml
@@ -12,6 +12,9 @@ vscodeMarketplace:
   release:
     eamodio:
     - gitlens
+    github:
+    - copilot
+    - copilot-chat
     ms-vscode-remote:
     - remote-ssh
     rust-lang:


### PR DESCRIPTION
The `vscode-marketplace` version of Copilot Chat basically always requires the Insiders version, thus making it impossible to install unless using VSCode Insiders.