### PR TITLE
feat(overrides.nix): add ms-vscode.cmake-tools sourceRoot config

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -9,5 +9,6 @@ in
 updateExtensions {
   # https://github.com/nix-community/nix-vscode-extensions/issues/31
   asf.apache-netbeans-java = _: { sourceRoot = "extension"; };
+  ms-vscode.cmake-tools = _: { sourceRoot = "extension"; };
   ms-dotnettools.csdevkit = _: { sourceRoot = "extension"; };
 }


### PR DESCRIPTION
This commit updates the overrides.nix file to include a new
configuration for the ms-vscode.cmake-tools extension, setting
the sourceRoot to "extension". This change is in line with the
existing pattern for other Visual Studio Code extensions.
