### PR TITLE
Make version takes precedence over platform

### DIFF
--- a/haskell/app/Main.hs
+++ b/haskell/app/Main.hs
@@ -238,7 +238,7 @@ runFetcher FetcherConfig{..} = do
       `catchAny` (\err -> runInIO $ logError (pack $ show err) >> pure [])
 
   let mkKey :: Publisher -> Name -> Platform -> Version -> LastUpdated -> (Publisher, Name, Platform, Version, LastUpdated)
-      mkKey publisher name platform version lastUpdated = (publisher, name, platform, version, lastUpdated)
+      mkKey publisher name platform version lastUpdated = (publisher, name, version, platform, lastUpdated)
       mkKeyInfo ExtensionInfo{..} = mkKey publisher name platform version lastUpdated
       mkKeyConfig ExtensionConfig{..} = mkKey publisher name platform version lastUpdated
       -- we load the cached info into a map for quicker access


### PR DESCRIPTION
The order of extension info is important because it dictates which extension is resolved when multiple revisions exist for the same name and same publisher.

At the moment, extensions are first sorted by platform, then by version. This makes any platform-specific extension override a universal extension of the same name and publisher, even if the platform-specific extension is of a lower version.

Sorting by version first ensures that extensions of the latest version end up last. Thus, if there is a universal extension of a higher version then a platform-specific extension, the universal extension will take precedence. However, if they are of the same version, the behavior is unchanged: the platform-specific extension will take precedence.

Fixes #58.