### PR TITLE
Patch vscode-lldb only on non-darwin systems

### DIFF
--- a/overrides.nix
+++ b/overrides.nix
@@ -3,9 +3,12 @@
 
   vadimcn.vscode-lldb = _: {
     postInstall = ''
-      cd "$out/$installPrefix"
-      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./adapter/codelldb
-      patchelf --add-rpath "${pkgs.lib.makeLibraryPath [ pkgs.zlib ]}" ./lldb/lib/liblldb.so
+      declare isDarwin=${if pkgs.stdenv.isDarwin then "true" else "false"}
+      if [[ $isDarwin == "false" ]]; then
+        cd "$out/$installPrefix"
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./adapter/codelldb
+        patchelf --add-rpath "${pkgs.lib.makeLibraryPath [ pkgs.zlib ]}" ./lldb/lib/liblldb.so
+      fi
     '';
   };
 

--- a/overrides.nix
+++ b/overrides.nix
@@ -2,13 +2,10 @@
 {
 
   vadimcn.vscode-lldb = _: {
-    postInstall = ''
-      declare isDarwin=${if pkgs.stdenv.isDarwin then "true" else "false"}
-      if [[ $isDarwin == "false" ]]; then
-        cd "$out/$installPrefix"
-        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./adapter/codelldb
-        patchelf --add-rpath "${pkgs.lib.makeLibraryPath [ pkgs.zlib ]}" ./lldb/lib/liblldb.so
-      fi
+    postInstall = pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+      cd "$out/$installPrefix"
+      patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" ./adapter/codelldb
+      patchelf --add-rpath "${pkgs.lib.makeLibraryPath [ pkgs.zlib ]}" ./lldb/lib/liblldb.so
     '';
   };
 


### PR DESCRIPTION
closes #63

The recent override for vscode-lldb does not work on Darwin systems. This PR changes the override to not patch on Darwin.
