### PR TITLE
fix(flake): don't remove extensions that aren't there

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -169,7 +169,9 @@
                 (
                   x:
                   builtins.foldl'
-                    (acc: y: acc // { "${y.publisher}" = builtins.removeAttrs acc."${y.publisher}" y.extensions; })
+                    (acc: y: if !acc?${y.publisher} then acc else
+                      acc // { "${y.publisher}" = builtins.removeAttrs acc.${y.publisher} y.extensions; }
+                    )
                     x
                     (
                       pkgs.lib.attrsets.mapAttrsToList (publisher: extensions: {


### PR DESCRIPTION
048cb176b6aba530d6fda75a6cc080a96499f6ae removes extensions from the output sets -- currently `ms-vscode.cpptools`.
But [open-vsx-release.json](https://github.com/nix-community/nix-vscode-extensions/blob/master/data/cache/open-vsx-release.json) does not specify that extension ('s publisher), and thus the removal failed.