### PR TITLE
Fix: update broken link for 'with-expressions' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ There are several attrsets:
 > [!NOTE]
 > In `with A; with B;`, the attributes of `B` shadow the attributes of `A`.
 > Keep in mind this property of `with` when writing `with vscode-marketplace; with vscode-marketplace-release;`.
-> See [With-expressions](https://nixos.org/manual/nix/unstable/language/constructs.html?highlight=langua#with-expressions).
+> See [With-expressions](https://nix.dev/manual/nix/latest/language/syntax#with-expressions).
 
 ### With flakes
 


### PR DESCRIPTION
The current link in the README redirects to `https://nix.dev/manual/nix/2.25/language/constructs.html#with-expressions`, which results in a "Page not found" error. This PR updates it to a working link: `https://nix.dev/manual/nix/latest/language/syntax#with-expressions`.