### PR TITLE
fix(vscode-lldb): add missing environment var

### DIFF
--- a/extensions/vadimcn/vscode-lldb/latest/adapter.nix
+++ b/extensions/vadimcn/vscode-lldb/latest/adapter.nix
@@ -21,6 +21,12 @@ let
     else
       "${lib.getBin lldb}/bin/lldb-server";
   LLVM_TRIPLE = stdenv.buildPlatform.rust.rustcTarget;
+  DYLIB_SUFFIX =
+    if stdenv.hostPlatform.isDarwin then
+      ".dylib"
+    else
+      ".so"
+    ;
 in
 rustPlatform.buildRustPackage {
   pname = "${pname}-adapter";
@@ -36,6 +42,7 @@ rustPlatform.buildRustPackage {
   LLDB_INCLUDE = "${lib.getDev lldb}/include";
   LLDB_LINK_LIB = "lldb";
   LLDB_LINK_SEARCH = "${lib.getLib lldb}/lib";
+  LLDB_DYLIB = "${lib.getLib lldb}/lib/liblldb${DYLIB_SUFFIX}";
 
   nativeBuildInputs = [ makeWrapper ];
 


### PR DESCRIPTION
Build currently failing due to missing environment variable, see: https://github.com/vadimcn/codelldb/blob/master/cargo_config.unix.toml For a list of expected variables.

closes #127