### PR TITLE
Increase maxMissingTimes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 collectGarbage: true
 garbageCollectorDelay: 10
 logSeverity: Info
-maxMissingTimes: 10
+maxMissingTimes: 100
 programTimeout: 3600
 openVSX:
   enable: true


### PR DESCRIPTION
Increase `maxMissingTimes` to increase the probability to get a newer version of the extension before evicting the cached version.