### PR TITLE
Fix build failures due to nixpkgs' expressions for extensions

### DIFF
--- a/mkExtension.nix
+++ b/mkExtension.nix
@@ -71,7 +71,11 @@ let
       # Wait for https://github.com/NixOS/nixpkgs/pull/383013 to be merged
       "vadimcn.vscode-lldb"
       "rust-lang.rust-analyzer"
-    ];
+    ]
+    ++
+    # Nixpkgs doesn't provide special fixes for these extensions.
+    # Therefore, no need to use expressions from nixpkgs.
+    [ "kilocode.kilo-code" ];
 
   pathSpecial = {
     ms-ceintl = "language-packs.nix";

--- a/mkExtension.nix
+++ b/mkExtension.nix
@@ -75,7 +75,10 @@ let
     ++
     # Nixpkgs doesn't provide special fixes for these extensions.
     # Therefore, no need to use expressions from nixpkgs.
-    [ "kilocode.kilo-code" ];
+    [
+      "kilocode.kilo-code"
+      "eamodio.gitlens"
+    ];
 
   pathSpecial = {
     ms-ceintl = "language-packs.nix";


### PR DESCRIPTION
Addresses: 
- #135

Extensions that currently don't need nixpkgs' expressions:
- `kilocode.kilo-code`
- `eamodio.gitlens`
