### PR TITLE
fix(nix): copy the callPackageWith function definition from nixpkgs because it was removed in nixpkgs

### DIFF
--- a/nix/mkExtension.nix
+++ b/nix/mkExtension.nix
@@ -45,7 +45,13 @@ let
 
   extensionsRemoved = (import ../removed.nix).${system} or [ ];
 
-  # Similar to callPackageWith/callPackage, but without makeOverridable
+  # Similar to callPackageWith/callPackage, but without makeOverridable.
+  # 
+  # In `nixpkgs`, `pkgs.lib.callPackageWith` uses `pkgs.lib.makeOverridable`.
+  # We need `callPackageWith` to use a custom `makeOverridable`
+  # to handle the case when in an expression for an extension in `nixpkgs`,
+  # `pkgs.vscode-utils.buildVscodeMarketplaceExtension`
+  # takes a function, not an attrset.
   # 
   # Adapted from
   # https://github.com/NixOS/nixpkgs/blob/b044ad6e5e92e70d7a7723864b0ab7a6c25bafda/pkgs/development/beam-modules/lib.nix#L9


### PR DESCRIPTION
- Fixes #152 