### PR TITLE
fix: change .zip to .vsix for nixos/nixpkgs#464215

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -225,7 +225,7 @@
                             # so we need to provide the URL for the extension
                             vsix = prev.fetchurl {
                               inherit url hash;
-                              name = "${name}-${version}.zip";
+                              name = "${name}-${version}.vsix";
                             };
 
                             inherit engineVersion platform isRelease;


### PR DESCRIPTION
vscode-utils removed unzip from nativeBuildInputs to only have .vsix extensions. This should be fine for Open VSX as well.