### PR TITLE
fix: decide file extension based on nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -225,7 +225,19 @@
                             # so we need to provide the URL for the extension
                             vsix = prev.fetchurl {
                               inherit url hash;
-                              name = "${name}-${version}.zip";
+                              name = let
+                                dummy_ext = pkgs.vscode-utils.buildVscodeExtension {
+                                  pname = "";
+                                  version = "";
+                                  src = "";
+                                  vscodeExtUniqueId = "";
+                                  vscodeExtPublisher = "";
+                                  vscodeExtName = "";
+                                };
+                                dummy_deps = builtins.map (x: x.name) dummy_ext.nativeBuildInputs;
+                                is_vsix = builtins.elem "unpack-vsix-setup-hook" dummy_deps;
+                                file_extension = if is_vsix then "vsix" else "zip";
+                              in "${name}-${version}.${file_extension}";
                             };
 
                             inherit engineVersion platform isRelease;


### PR DESCRIPTION
Fixes #160 (caused by NixOS/nixpkgs#464215).

Based on #161, but doesn't break on stable Nixpkgs.