### PR TITLE
fix(nix): treat extensions created via `buildVscodeExtension` as problematic

### DIFF
--- a/nix/mkExtension.nix
+++ b/nix/mkExtension.nix
@@ -99,9 +99,16 @@ let
     # using the `buildVscodeExtension` function.
     #
     # Their expressions don't provide any meaningful fixes.
+    # 
+    # Find all such extensions:
+    # https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20buildVscodeExtension&type=code
     "eamodio.gitlens"
+    "google.gemini-cli-vscode-ide-companion"
     "kilocode.kilo-code"
+    "ms-vscode.js-debug-companion"
+    "ms-vscode.vscode-js-profile-table"
     "prettier.prettier-vscode"
+    "rooveterinaryinc.roo-cline"
     "vscode-icons-team.vscode-icons"
   ];
 


### PR DESCRIPTION
## Motivation

Related to:
- #172
- https://github.com/nix-community/nix-vscode-extensions/issues/135#issuecomment-3615658618


## Changes

- Treat extensions created via `buildVscodeExtension` as problematic.
- Use only their `meta`.
- Assume they don't have useful fixes in `nixpkgs`.
- Use `buildVscodeMarketplaceExtension` to build packages for problematic extensions from fetched `vsix` rather than expressions from `nixpkgs`.